### PR TITLE
SDE-42 different view for users and posts

### DIFF
--- a/src/components/app/AppContainer.js
+++ b/src/components/app/AppContainer.js
@@ -28,8 +28,8 @@ const AppContainer = () => {
   };
 
   //Make API call with request data
-  const fetchAndSetData = request => {    
-    APICall(request).then( (result) => {           
+  const fetchAndSetData = request => { 
+    APICall(request).then( (result) => { 
       setMaxPages(Math.ceil(result.TotalResults / request.results));
       setData(result.Results);
       }

--- a/src/components/app/AppContainer.js
+++ b/src/components/app/AppContainer.js
@@ -29,8 +29,8 @@ const AppContainer = () => {
 
   //Make API call with request data
   const fetchAndSetData = request => {    
-    APICall(request).then( (result) => {      
-      setMaxPages(Math.ceil(result.TotalResults / request.ResultCount));
+    APICall(request).then( (result) => {           
+      setMaxPages(Math.ceil(result.TotalResults / request.results));
       setData(result.Results);
       }
     ).catch( error => { 

--- a/src/components/list/ResultList.jsx
+++ b/src/components/list/ResultList.jsx
@@ -4,9 +4,17 @@ import './ResultList.css';
 
 const ResultList = ({ data }) => (
   <ul className="result-list">
-    {data.map((value, index) => <li key={index}>{resultFormat(value)}</li>)}
+    {data.map((value, index) => <li key={index}>{showResults(value)}</li>)}
   </ul>
 );
+
+const showResults = (result) => {  
+  switch ( result.Type ) {
+    case "posts" : return resultFormat(result);
+    case "users" : return userFormat(result);
+    default: return;
+  }  
+}
 
 const resultFormat = ({ UserID, DateCreated, Content, Tags }) => (
   <div className="container-result-row">
@@ -22,6 +30,21 @@ const resultFormat = ({ UserID, DateCreated, Content, Tags }) => (
       <i>
         {Tags.map(tag => `${tag} `)}
       </i>
+    </div>
+  </div>
+);
+
+const userFormat = ({ UserID, LastName, FirstName, EmailAddress }) => (
+  <div className="container-result-row">
+    <div className="container-result-row-contents container-result-row-user-date">
+      <div>{UserID}</div>      
+    </div>
+    <hr />
+    <div className="container-result-row-contents container-result-row-content">
+      {FirstName} {LastName}
+    </div>
+    <div className="container-result-row-contents container-result-row-tags">      
+      {EmailAddress}      
     </div>
   </div>
 );

--- a/src/components/list/ResultList.jsx
+++ b/src/components/list/ResultList.jsx
@@ -10,13 +10,13 @@ const ResultList = ({ data }) => (
 
 const showResults = ( result ) => {  
   switch ( result.Type ) {
-    case "posts" : return resultFormat(result);
+    case "posts" : return postFormat(result);
     case "users" : return userFormat(result);
     default: return;
   }  
 }
 
-const resultFormat = ({ UserID, DateCreated, Content, Tags }) => (
+const postFormat = ({ UserID, DateCreated, Content, Tags }) => (
   <div className="container-result-row">
     <div className="container-result-row-contents container-result-row-user-date">
       <div>{UserID}</div>

--- a/src/components/list/ResultList.jsx
+++ b/src/components/list/ResultList.jsx
@@ -8,7 +8,7 @@ const ResultList = ({ data }) => (
   </ul>
 );
 
-const showResults = (result) => {  
+const showResults = ( result ) => {  
   switch ( result.Type ) {
     case "posts" : return resultFormat(result);
     case "users" : return userFormat(result);


### PR DESCRIPTION
Allow users records to be shown, currently if a user record is included in a results match the page errors out. 

This gives 2 different formats within ResultsList.jsx which can be used to style the views differently and deal with the array destructuring for the different fields. 

Currently the view is the same, just with different fields shown